### PR TITLE
adds test for propogateErrors middleware option

### DIFF
--- a/src/express-middleware.js
+++ b/src/express-middleware.js
@@ -44,6 +44,7 @@ export function createExpressMiddleware(adapter, middlewareOptions = {}) {
   function handleError(error, res, next) {
     if (middlewareOptions.propagateErrors) {
       next(error);
+      return;
     }
     const respond = sendResponse(res);
     if (adapter.waitForResponse) {

--- a/test/integration/test-middleware-options.js
+++ b/test/integration/test-middleware-options.js
@@ -1,0 +1,46 @@
+var http = require('http');
+var assert = require('assert');
+var express = require('express');
+var bodyParser = require('body-parser');
+var request = require('superagent');
+var createSlackEventAdapter = require('../../dist').createSlackEventAdapter;
+
+var helpers = require('../helpers');
+
+describe('when using middleware propogate errors option', function () {
+  beforeEach(function (done) {
+    this.port = process.env.PORT || '8080';
+    this.verificationToken = 'VERIFICATION_TOKEN';
+    this.adapter = createSlackEventAdapter(this.verificationToken);
+    this.app = express();
+    this.app.use(bodyParser.json());
+    this.app.use('/slack', this.adapter.expressMiddleware({
+      propagateErrors: true
+    }));
+    this.server = http.createServer(this.app);
+    this.server.listen(this.port, done);
+  });
+
+  afterEach(function (done) {
+    this.server.close(done);
+  });
+
+  it('should propogate errors to express error handlers', function (done) {
+    var partiallyComplete = helpers.completionAggregator(done, 2);
+    var payload = {
+      token: 'NOT_THE_RIGHT_VERIFICATION_TOKEN',
+      event: {}
+    };
+    this.app.use(function (err, req, res, next) { // eslint-disable-line no-unused-vars
+      assert(err instanceof Error);
+      res.sendStatus(500);
+      partiallyComplete();
+    });
+    request
+      .post('http://localhost:' + this.port + '/slack')
+      .send(payload)
+      .end(function () {
+        partiallyComplete();
+      });
+  });
+});


### PR DESCRIPTION
###  Summary

adds test for propogateErrors middleware option

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/node-slack-events-api/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackapi/node-slack-events-api).
