### PR TITLE
adds note about not being enterprise ready to the sample

### DIFF
--- a/examples/greet-and-react/index.js
+++ b/examples/greet-and-react/index.js
@@ -18,6 +18,9 @@ const slackEvents = slackEventsApi.createSlackEventAdapter(process.env.SLACK_VER
 const botAuthorizations = {}
 
 // Helpers to cache and lookup appropriate client
+// NOTE: Not enterprise-ready. if the event was triggered inside a shared channel, this lookup
+// could fail but there might be a suitable client from one of the other teams that is within that
+// shared channel.
 const clients = {};
 function getClientByTeamId(teamId) {
   if (!clients[teamId] && botAuthorizations[teamId]) {


### PR DESCRIPTION
###  Summary

Give the user information about reason why the example is not enterprise ready.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/node-slack-events-api/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
