### PR TITLE
changes the default server's listening path to '/slack/events'

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ for free.
 section. This URL depends on how you used the previous two commands. For example, using the
 default path and the subdomain name "mybot":
 
-  > With ngrok: `https://mybot.ngrok.io/event`
+  > With ngrok: `https://mybot.ngrok.io/slack/events`
 
-  > With localtunnel: `https://mybot.localtunnel.me/event`
+  > With localtunnel: `https://mybot.localtunnel.me/slack/events`
 
 4.  Once the verification is complete, you can terminate the two processes (verification tool and
 development server). You can proceed to selecting the event types your App needs.
@@ -101,7 +101,7 @@ app.use(bodyParser.json());
 
 // Mount the event handler on a route
 // NOTE: you must mount to a path that matches the Request URL that was configured earlier
-app.use('/event', slackEvents.expressMiddleware());
+app.use('/slack/events', slackEvents.expressMiddleware());
 
 // Attach listeners to events by Slack Event "type". See: https://api.slack.com/events/message.im
 slackEvents.on('message', (event)=> {

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ URL, you will get a verification failure, but also there will now be a **Verific
 available in the Basic Information section.
 
 1.  Start the verification tool:
-`./node_modules/.bin/slack-verify --token <token> [--path=/event] [--port=3000]`. You will need to
-substitute your own Verification Token for `<token>`. You may also want to choose your own `path`
-and/or `port`.
+`./node_modules/.bin/slack-verify --token <token> [--path=/slack/events] [--port=3000]`. You will
+need to substitute your own Verification Token for `<token>`. You may also want to choose your own
+`path` and/or `port`.
 
 2.  Start your development proxy. We recommend using [ngrok](https://ngrok.com/) for its stability,
 but using a custom subdomain will require a paid plan. Otherwise,

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -61,7 +61,7 @@ errors, but instead invokes `next(error)` so that your next route handler can se
 #### start(_port_)
 
 This method is a convenience API that will create an HTTP server, set it up to receive requests
-from the Slack Events API at the default path of `/event`, and start listening on a port. It
+from the Slack Events API at the default path of `/slack/events`, and start listening on a port. It
 returns a Promise that resolves when the server is listening.
 
 #### createServer([_path_])
@@ -69,5 +69,5 @@ returns a Promise that resolves when the server is listening.
 This method returns a Promise for an
 [`http.Server`](https://nodejs.org/dist/latest-v4.x/docs/api/http.html#http_class_http_server). The
 server will already be setup to receive requests from the Slack Events API at the default path of
-`/event`. A specific path can be set using the `path` argument. You can start it by calling the
-`listen()` method on the server.
+`/slack/events`. A specific path can be set using the `path` argument. You can start it by calling
+the `listen()` method on the server.

--- a/examples/greet-and-react/index.js
+++ b/examples/greet-and-react/index.js
@@ -62,7 +62,7 @@ app.get('/auth/slack/callback',
 );
 
 // *** Plug the event adapter into the express app as middleware ***
-app.use('/event', slackEvents.expressMiddleware());
+app.use('/slack/events', slackEvents.expressMiddleware());
 
 // *** Attach listeners to the event adapter ***
 

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -18,7 +18,7 @@ export default class SlackEventAdapter extends EventEmitter {
   }
 
   // TODO: options (like https)
-  createServer(path = '/event') {
+  createServer(path = '/slack/events') {
     // NOTE: this is a workaround for a shortcoming of the System.import() tranform
     return Promise.resolve().then(() => Promise.all([
       System.import('express'),

--- a/src/verify.js
+++ b/src/verify.js
@@ -14,7 +14,7 @@ const argv = yargs
     path: {
       alias: 'p',
       describe: 'The path (part of URL after hostname and port) that resolves to your Request URL in the App management page',
-      default: '/event',
+      default: '/slack/events',
       type: 'string',
     },
     port: {


### PR DESCRIPTION
###  Summary

The old default path for `SlackEventAdapter.createServer()` and `SlackEventAdapter.start()` was `/event`. We decided that it would be safer to "namespace" it and this would make room to plug in future modules that may use the same paradigms. Its now `/slack/events`.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/node-slack-events-api/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
