### PR TITLE
add debug logging. fixes #19

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "superagent": "^3.3.1"
   },
   "dependencies": {
+    "debug": "^2.6.1",
     "lodash.isstring": "^4.0.1",
     "yargs": "^6.6.0"
   }

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -1,7 +1,10 @@
 import EventEmitter from 'events';
 import http from 'http';
 import isString from 'lodash.isstring';
+import debugFactory from 'debug';
 import { createExpressMiddleware } from './express-middleware';
+
+const debug = debugFactory('@slack/events-api:adapter');
 
 export default class SlackEventAdapter extends EventEmitter {
   constructor(verificationToken, options = {}) {
@@ -15,6 +18,12 @@ export default class SlackEventAdapter extends EventEmitter {
     this.includeBody = !!options.includeBody || false;
     this.includeHeaders = !!options.includeHeaders || false;
     this.waitForResponse = !!options.waitForResponse || false;
+
+    debug('adapter instantiated - options: %o', {
+      includeBody: this.includeBody,
+      includeHeaders: this.includeHeaders,
+      waitForResponse: this.waitForResponse,
+    });
   }
 
   // TODO: options (like https)
@@ -37,6 +46,8 @@ export default class SlackEventAdapter extends EventEmitter {
       app.use(bodyParser.json());
       app.post(path, this.expressMiddleware());
 
+      debug('server created - path: %s', path);
+
       return http.createServer(app);
     });
   }
@@ -46,6 +57,7 @@ export default class SlackEventAdapter extends EventEmitter {
       .then(server => new Promise((resolve, reject) => {
         server.on('error', reject);
         server.listen(port, () => resolve(server));
+        debug('server started - port: %s', port);
       }));
   }
 

--- a/src/express-middleware.js
+++ b/src/express-middleware.js
@@ -43,7 +43,7 @@ export function createExpressMiddleware(adapter, middlewareOptions = {}) {
       // Lastly, send the response
       const content = responseOptions.content || '';
       debug('response body: %s', content);
-      res.send();
+      res.send(content);
       res.on('finish', () => {
         // NOTE: uses undocumented API of http.ServerResponse, but OK for logging code
         // eslint-disable-next-line no-underscore-dangle

--- a/src/express-middleware.js
+++ b/src/express-middleware.js
@@ -45,7 +45,9 @@ export function createExpressMiddleware(adapter, middlewareOptions = {}) {
       debug('response body: %s', content);
       res.send(content);
       res.on('finish', () => {
-        // NOTE: uses undocumented API of http.ServerResponse, but OK for logging code
+        // res._headers is an undocumented property, but we feel comfortable using it because:
+        // 1. express depends on it and express is so foundational in node
+        // 2. this is logging code and the risk of this causing a break is minimal
         // eslint-disable-next-line no-underscore-dangle
         debug('response finished - status: %d, headers: %o', res.statusCode, res._headers);
       });
@@ -120,8 +122,9 @@ export function createExpressMiddleware(adapter, middlewareOptions = {}) {
       debug('emitting event -  type: %s, arguments: %o', req.body.event.type, emitArguments);
       adapter.emit(req.body.event.type, ...emitArguments);
     } catch (error) {
-      // TODO: these errors will never have codes, but otherwise this message should look like the
-      // one in handleError()
+      // TODO: there's an opportunity to refactor this code along with the code inside
+      // handleError(). the main difference is that errors in this code path will not have a `code`
+      // property.
       debug('emitting error - %o', error);
       adapter.emit('error', error);
     }


### PR DESCRIPTION
###  Summary

Adds debug logging. To see logs, set the `DEBUG` environment variable. You could get individual modules by specifying them by name (e.g. `DEBUG=@slack/events-api:express-middleware`) or just look at all the logs from this package (e.g. `DEBUG=@slack/events-api:*`).

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/node-slack-events-api/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
