### PR TITLE
address typo and clarify  option use cases

### DIFF
--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -89,7 +89,7 @@ Labels are used to run issues through an organized workflow. Here are the basic 
 *  `docs`: An issue that is purely about documentation work.
 *  `tests`: An issue that is purely about testing work.
 *  `needs feedback`: An issue that may have claimed to be a bug but was not reproducible, or was otherwise missing some information.
-*  `discussion`: An issue that is purely meant to hold a discussion. Typically the maintainers are looking for feedback in this issues.
+*  `discussion`: An issue that is purely meant to hold a discussion. Typically the maintainers are looking for feedback in this issue.
 *  `question`: An issue that is like a support request because the user's usage was not correct.
 *  `semver:major|minor|patch`: Metadata about how resolving this issue would affect the version number.
 *  `security`: An issue that has special consideration for security reasons.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -39,7 +39,7 @@ parsed body of the HTTP request. This can be useful to get additional context su
 `api_app_id`, and more. Similarly, if you initialized the adapter using the `includeHeaders` option,
 the next argument will be an object with key-value pairs for the headers in the HTTP request.
 
-If you initialize the adapter ueing the `waitForResponse` option, an additional callback argument,
+If you initialize the adapter using the `waitForResponse` option, an additional callback argument,
 `respond()`, will be emitted with your events. When using this option, the adapter will not respond
 to HTTP requests until you have invoked the callback. The callback has a signature of
 `respond(error, responseOptions)`. If you want to respond with a general failure, you should set the
@@ -48,7 +48,10 @@ that Slack should not retry that request, you should set `responseOptions.failWi
 truthy value. If you want Slack to send the request to a different URL, you should set the
 value of `responseOptions.redirectLocation` to the URL you want. Lastly, if you'd like to
 set the body of the response, you should set the `responseOptions.content` value to a String of
-body content.
+body content. EventEmitters allow you to add many handlers, but its recommended that when using the
+`waitForResponse` option that you only have one handler on each event type. You should always handle
+the `error` event too. It's your application's responsibility to make sure that the `respond()`
+callback is invoked exactly once.
 
 #### expressMiddleware([_options_])
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -48,7 +48,7 @@ that Slack should not retry that request, you should set `responseOptions.failWi
 truthy value. If you want Slack to send the request to a different URL, you should set the
 value of `responseOptions.redirectLocation` to the URL you want. Lastly, if you'd like to
 set the body of the response, you should set the `responseOptions.content` value to a String of
-body content. EventEmitters allow you to add many handlers, but its recommended that when using the
+body content. EventEmitters allow you to add many handlers, but it's recommended when using the
 `waitForResponse` option that you only have one handler on each event type. You should always handle
 the `error` event too. It's your application's responsibility to make sure that the `respond()`
 callback is invoked exactly once.


### PR DESCRIPTION
###  Summary

Just making the docs a little clearer.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/node-slack-events-api/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
