### PR TITLE
adds SlackEventAdapter.stop() method

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -55,10 +55,28 @@ export default class SlackEventAdapter extends EventEmitter {
   start(port) {
     return this.createServer()
       .then(server => new Promise((resolve, reject) => {
+        this.server = server;
         server.on('error', reject);
         server.listen(port, () => resolve(server));
         debug('server started - port: %s', port);
       }));
+  }
+
+  stop() {
+    return new Promise((resolve, reject) => {
+      if (this.server) {
+        this.server.close((error) => {
+          delete this.server;
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
+      } else {
+        reject(new Error('SlackEventAdapter cannot stop when it did not start a server'));
+      }
+    });
   }
 
   expressMiddleware(middlewareOptions = {}) {

--- a/test/integration/test-basic.js
+++ b/test/integration/test-basic.js
@@ -165,7 +165,11 @@ describe('when using the built-in HTTP server', function () {
           })
           .catch(function (error) {
             assert(error instanceof Error);
-            done();
+            self.adapter.start(self.port)
+              .then(function () {
+                done();
+              })
+              .catch(done);
           });
       })
       .catch(done);

--- a/test/integration/test-basic.js
+++ b/test/integration/test-basic.js
@@ -130,3 +130,28 @@ describe('when using middleware inside your own express application', function (
       });
   });
 });
+
+describe('when using the built-in HTTP server', function () {
+  beforeEach(function () {
+    this.port = process.env.PORT || '8080';
+    // This is the default path
+    this.path = '/slack/events';
+    this.verificationToken = 'VERIFICATION_TOKEN';
+    this.adapter = createSlackEventAdapter(this.verificationToken, {
+      waitForResponse: true
+    });
+    return this.adapter.start(this.port);
+  });
+
+  afterEach(function () {
+    return this.adapter.stop();
+  });
+
+  it('should be able to stop the built-in HTTP server', function () {
+    var self = this;
+    return self.adapter.stop()
+      .then(function () {
+        return self.adapter.start(self.port);
+      });
+  });
+});

--- a/test/integration/test-basic.js
+++ b/test/integration/test-basic.js
@@ -154,4 +154,20 @@ describe('when using the built-in HTTP server', function () {
         return self.adapter.start(self.port);
       });
   });
+
+  it('should not stop if there is no built-in HTTP server running', function (done) {
+    var self = this;
+    self.adapter.stop()
+      .then(function () {
+        self.adapter.stop()
+          .then(function () {
+            done(new Error('should not be able to stop an already stopped server'));
+          })
+          .catch(function (error) {
+            assert(error instanceof Error);
+            done();
+          });
+      })
+      .catch(done);
+  });
 });


### PR DESCRIPTION
###  Summary

fixes #27

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/node-slack-events-api/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
