### PR TITLE
refactors error handling to emit respond function

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "eslint-plugin-jsx-a11y": "^2.2.3",
     "eslint-plugin-react": "^6.8.0",
     "express": "^4.14.0",
+    "lodash.isfunction": "^3.0.8",
     "mocha": "^3.2.0",
+    "nop": "^1.0.0",
     "nyc": "^10.0.0",
     "proxyquire": "^1.7.10",
     "superagent": "^3.3.1"

--- a/src/express-middleware.js
+++ b/src/express-middleware.js
@@ -15,7 +15,11 @@ const responseStatuses = {
 const debug = debugFactory('@slack/events-api:express-middleware');
 
 export function createExpressMiddleware(adapter, middlewareOptions = {}) {
+  // This function binds a specific response instance to a function that works more like a
+  // a completion handler; one which follows the error-first argument pattern.
   function sendResponse(res) {
+    // This function is the completion handler for sending a response to an event. It can either
+    // be invoked by automatically or by the user (when using the `waitForResponse` option).
     return function _sendResponse(err, responseOptions = {}) {
       debug('sending response - error: %s, responseOptions: %o', err, responseOptions);
       // Deal with errors up front
@@ -54,14 +58,17 @@ export function createExpressMiddleware(adapter, middlewareOptions = {}) {
     };
   }
 
-  function handleError(error, res, next) {
+  // This function abstracts handling of an error. It inspects the relevant options to dispatch the
+  // error using the right interface (either the next middleware or emitted from
+  // the adapter) and handles the respond function.
+  function handleError(error, respond, next) {
     debug('handling error - message: %s, code: %s', error.message, error.code);
     if (middlewareOptions.propagateErrors) {
       debug('propagating error for next middleware');
+      // The respond function is never invoked because the next middleware is expected to respond
       next(error);
       return;
     }
-    const respond = sendResponse(res);
     if (adapter.waitForResponse) {
       adapter.emit('error', error, respond);
     } else {
@@ -72,11 +79,16 @@ export function createExpressMiddleware(adapter, middlewareOptions = {}) {
 
   return function slackEventAdapterMiddleware(req, res, next) {
     debug('request recieved - method: %s, path: %s', req.method, req.path);
+
+    // Bind a response function to this request's respond object. This may be used in a number of
+    // places
+    const respond = sendResponse(res);
+
     // Check that the request body has been parsed
     if (!req.body) {
       const error = new Error('The incoming HTTP request did not have a parsed body.');
       error.code = errorCodes.NO_BODY_PARSER;
-      handleError(error, res, next);
+      handleError(error, respond, next);
       return;
     }
 
@@ -88,11 +100,11 @@ export function createExpressMiddleware(adapter, middlewareOptions = {}) {
         const error = new Error('Slack event challenge failed.');
         error.code = errorCodes.TOKEN_VERIFICATION_FAILURE;
         error.body = req.body;
-        handleError(error, res, next);
+        handleError(error, respond, next);
         return;
       }
       debug('url verification success');
-      sendResponse(res)(null, { content: req.body.challenge });
+      respond(null, { content: req.body.challenge });
       return;
     }
 
@@ -102,7 +114,7 @@ export function createExpressMiddleware(adapter, middlewareOptions = {}) {
       const error = new Error('Slack event verification failed');
       error.code = errorCodes.TOKEN_VERIFICATION_FAILURE;
       error.body = req.body;
-      handleError(error, res, next);
+      handleError(error, respond, next);
       return;
     }
     debug('request token verification success');
@@ -115,22 +127,16 @@ export function createExpressMiddleware(adapter, middlewareOptions = {}) {
       emitArguments.push(req.headers);
     }
     if (adapter.waitForResponse) {
-      emitArguments.push(sendResponse(res));
+      emitArguments.push(respond);
+    } else {
+      respond();
     }
 
     try {
       debug('emitting event -  type: %s, arguments: %o', req.body.event.type, emitArguments);
       adapter.emit(req.body.event.type, ...emitArguments);
     } catch (error) {
-      // TODO: there's an opportunity to refactor this code along with the code inside
-      // handleError(). the main difference is that errors in this code path will not have a `code`
-      // property.
-      debug('emitting error - %o', error);
-      adapter.emit('error', error);
-    }
-
-    if (!adapter.waitForResponse) {
-      sendResponse(res)();
+      handleError(error, respond, next);
     }
   };
 }

--- a/test/integration/test-adapter-options.js
+++ b/test/integration/test-adapter-options.js
@@ -1,0 +1,103 @@
+var assert = require('assert');
+var request = require('superagent');
+var createSlackEventAdapter = require('../../dist').createSlackEventAdapter;
+
+var isFunction = require('lodash.isfunction');
+
+describe('when using the waitForResponse option', function () {
+  beforeEach(function () {
+    this.port = process.env.PORT || '8080';
+    // This is the default path
+    this.path = '/slack/events';
+    this.verificationToken = 'VERIFICATION_TOKEN';
+    this.adapter = createSlackEventAdapter(this.verificationToken, {
+      waitForResponse: true
+    });
+    return this.adapter.start(this.port);
+  });
+
+  afterEach(function () {
+    return this.adapter.stop();
+  });
+
+  it('should emit a respond function with events', function (done) {
+    var payload = {
+      token: this.verificationToken,
+      event: {
+        type: 'any_event',
+        key: 'value',
+        foo: 'baz'
+      }
+    };
+    this.adapter.on('any_event', function (event, respond) {
+      assert(isFunction(respond));
+      respond();
+    });
+    request
+      .post('http://localhost:' + this.port + this.path)
+      .send(payload)
+      .end(function (err, res) {
+        if (err) {
+          done(err);
+        } else {
+          assert.equal(res.statusCode, 200);
+          done();
+        }
+      });
+  });
+
+  it('should emit a respond function with errors that originate from user code', function (done) {
+    var payload = {
+      token: this.verificationToken,
+      event: {
+        type: 'any_event',
+        key: 'value',
+        foo: 'baz'
+      }
+    };
+    this.adapter.on('any_event', function () {
+      throw new Error();
+    });
+    this.adapter.on('error', function (event, respond) {
+      assert(isFunction(respond));
+      respond();
+    });
+    request
+      .post('http://localhost:' + this.port + this.path)
+      .send(payload)
+      .end(function (err, res) {
+        if (err) {
+          done(err);
+        } else {
+          assert.equal(res.statusCode, 200);
+          done();
+        }
+      });
+  });
+
+  it('should emit a respond function with errors that originate from known failures', function (done) {
+    var payload = {
+      token: 'NOT_THE_RIGHT_VERIFICATION_TOKEN',
+      event: {
+        type: 'any_event',
+        key: 'value',
+        foo: 'baz'
+      }
+    };
+    this.adapter.on('error', function (error, respond) {
+      assert(isFunction(respond));
+      respond();
+    });
+    request
+      .post('http://localhost:' + this.port + this.path)
+      .send(payload)
+      .end(function (err, res) {
+        if (err) {
+          done(err);
+        } else {
+          assert.equal(res.statusCode, 200);
+          done();
+        }
+      });
+  });
+});

--- a/test/unit/test-middleware.js
+++ b/test/unit/test-middleware.js
@@ -2,6 +2,7 @@ var assert = require('assert');
 var systemUnderTest = require('../../dist/express-middleware');
 var createExpressMiddleware = systemUnderTest.createExpressMiddleware;
 var errorCodes = systemUnderTest.errorCodes;
+var noop = require('nop');
 
 // NOTE: Unit testing the middleware module is not very effective because mocking its dependencies
 // beyond just the trivial cases requires too much effort. Instead of depending on thorough unit
@@ -37,6 +38,9 @@ describe('expressMiddleware', function () {
       }
     };
     var res = {
+      set: noop,
+      send: noop,
+      on: noop
     };
     function next() {
       assert(false);


### PR DESCRIPTION
###  Summary

fixes #18

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing guidelines](https://github.com/slackapi/node-slack-events-api/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
