### PR TITLE
Export verifyRequestSignature

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -26,9 +26,9 @@ A helper method for verifying a request signature according to the docs here: ht
 The `params.signingSecret` is a required string parameter which you can find in your Slack app's Basic
 Information.
 
-The `params.requestSignature` is a required string parameter taken from the 'x-slack-signature' header of your request.
+The `params.requestSignature` is a required string parameter taken from the 'x-slack-signature' header of the request.
 
-The `params.requestTimestamp` is a required numeric parameter taken from the 'x-slack-request-timestamp' header of your request.
+The `params.requestTimestamp` is a required numeric parameter taken from the 'x-slack-request-timestamp' header of the request.
 
 The `params.body` is a required string parameter for the raw, unparsed request body. If your application automatically parses JSON request you may need to retrieve the raw body prior to parsing.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -19,6 +19,19 @@ If `options.includeHeaders` is truthy, then the SlackEventAdapter will emit an a
 with the event that has the parsed headers of the HTTP request. See SlackEventAdapter for more
 details.
 
+#### verifyRequestSignature([_params_])
+
+A helper method for verifying a request signature according to the docs here: https://api.slack.com/docs/verifying-requests-from-slack
+
+The `params.signingSecret` is a required string parameter which you can find in your Slack app's Basic
+Information.
+
+The `params.requestSignature` is a required string parameter taken from the 'x-slack-signature' header of your request.
+
+The `params.requestTimestamp` is a required numeric parameter taken from the 'x-slack-request-timestamp' header of your request.
+
+The `params.body` is a required string parameter for the raw, unparsed request body. If your application automatically parses JSON request you may need to retrieve the raw body prior to parsing.
+
 ### SlackEventAdapter
 
 This object is responsible for consuming HTTP requests from the Slack Events API (via a request handler or

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import { errorCodes as adapterErrorCodes, SlackEventAdapter } from './adapter';
 
+export { verifyRequestSignature } from './http-handler';
 export const errorCodes = adapterErrorCodes;
 
 export function createEventAdapter(signingSecret, options) {

--- a/test/unit/test-http-handler.js
+++ b/test/unit/test-http-handler.js
@@ -7,114 +7,145 @@ var systemUnderTest = proxyquire('../../dist/http-handler', {
   'raw-body': getRawBodyStub
 });
 var createHTTPHandler = systemUnderTest.createHTTPHandler;
+var verifyRequestSignature = systemUnderTest.verifyRequestSignature;
 
 // fixtures
 var correctSigningSecret = 'SIGNING_SECRET';
 var correctRawBody = '{"type":"event_callback","event":{"type":"reaction_added",' +
 '"user":"U123","item":{"type":"message","channel":"C123"}}}';
 
-describe('createHTTPHandler', function () {
+describe('http-handler', function () {
   beforeEach(function () {
-    this.emit = sinon.stub();
-    this.res = sinon.stub({
-      setHeader: function () { },
-      send: function () { },
-      end: function () { }
-    });
-    this.next = sinon.stub();
     this.correctDate = Math.floor(Date.now() / 1000);
-    this.requestListener = createHTTPHandler({
-      signingSecret: correctSigningSecret,
-      emit: this.emit
+  });
+
+  describe('verifyRequestSignature', function () {
+    it('should return true for a valid request', function () {
+      var req = createRequest(correctSigningSecret, this.correctDate, correctRawBody);
+      var isVerified = verifyRequestSignature({
+        signingSecret: correctSigningSecret,
+        requestTimestamp: req.headers['x-slack-request-timestamp'],
+        requestSignature: req.headers['x-slack-signature'],
+        body: req.body
+      });
+
+      assert.isTrue(isVerified);
+    });
+
+    it('should throw for a request signed with a different secret', function () {
+      var req = createRequest(correctSigningSecret, this.correctDate, correctRawBody);
+      assert.throws(() => verifyRequestSignature({
+        signingSecret: 'INVALID_SECRET',
+        requestTimestamp: req.headers['x-slack-request-timestamp'],
+        requestSignature: req.headers['x-slack-signature'],
+        body: req.body
+      }), 'Slack request signing verification failed');
     });
   });
 
-  it('should verify a correct signing secret', function (done) {
-    var emit = this.emit;
-    var res = this.res;
-    var req = createRequest(correctSigningSecret, this.correctDate, correctRawBody);
-    emit.resolves({ status: 200 });
-    getRawBodyStub.resolves(correctRawBody);
-    res.end.callsFake(function () {
-      assert.equal(res.statusCode, 200);
-      done();
+  describe('createHTTPHandler', function () {
+    beforeEach(function () {
+      this.emit = sinon.stub();
+      this.res = sinon.stub({
+        setHeader: function () { },
+        send: function () { },
+        end: function () { }
+      });
+      this.next = sinon.stub();
+      this.correctDate = Math.floor(Date.now() / 1000);
+      this.requestListener = createHTTPHandler({
+        signingSecret: correctSigningSecret,
+        emit: this.emit
+      });
     });
-    this.requestListener(req, res);
-  });
 
-  it('should fail request signing verification with an incorrect signing secret', function (done) {
-    var res = this.res;
-    var req = createRequest('INVALID_SECRET', this.correctDate, correctRawBody);
-    getRawBodyStub.resolves(correctRawBody);
-    res.end.callsFake(function () {
-      assert.equal(res.statusCode, 404);
-      done();
+    it('should verify a correct signing secret', function (done) {
+      var emit = this.emit;
+      var res = this.res;
+      var req = createRequest(correctSigningSecret, this.correctDate, correctRawBody);
+      emit.resolves({ status: 200 });
+      getRawBodyStub.resolves(correctRawBody);
+      res.end.callsFake(function () {
+        assert.equal(res.statusCode, 200);
+        done();
+      });
+      this.requestListener(req, res);
     });
-    this.requestListener(req, res);
-  });
 
-  it('should fail request signing verification with old timestamp', function (done) {
-    var res = this.res;
-    var sixMinutesAgo = Math.floor(Date.now() / 1000) - (60 * 6);
-    var req = createRequest(correctSigningSecret, sixMinutesAgo, correctRawBody);
-    getRawBodyStub.resolves(correctRawBody);
-    res.end.callsFake(function () {
-      assert.equal(res.statusCode, 404);
-      done();
+    it('should fail request signing verification with an incorrect signing secret', function (done) {
+      var res = this.res;
+      var req = createRequest('INVALID_SECRET', this.correctDate, correctRawBody);
+      getRawBodyStub.resolves(correctRawBody);
+      res.end.callsFake(function () {
+        assert.equal(res.statusCode, 404);
+        done();
+      });
+      this.requestListener(req, res);
     });
-    this.requestListener(req, res);
-  });
 
-  it('should handle unexpected error', function (done) {
-    var res = this.res;
-    var req = createRequest(correctSigningSecret, this.correctDate, correctRawBody);
-    getRawBodyStub.rejects(new Error('test error'));
-    res.end.callsFake(function (result) {
-      assert.equal(res.statusCode, 500);
-      assert.isUndefined(result);
-      done();
+    it('should fail request signing verification with old timestamp', function (done) {
+      var res = this.res;
+      var sixMinutesAgo = Math.floor(Date.now() / 1000) - (60 * 6);
+      var req = createRequest(correctSigningSecret, sixMinutesAgo, correctRawBody);
+      getRawBodyStub.resolves(correctRawBody);
+      res.end.callsFake(function () {
+        assert.equal(res.statusCode, 404);
+        done();
+      });
+      this.requestListener(req, res);
     });
-    this.requestListener(req, res);
-  });
 
-  it('should provide message with unexpected errors in development', function (done) {
-    var res = this.res;
-    var req = createRequest(correctSigningSecret, this.correctDate, correctRawBody);
-    process.env.NODE_ENV = 'development';
-    getRawBodyStub.rejects(new Error('test error'));
-    res.end.callsFake(function (result) {
-      assert.equal(res.statusCode, 500);
-      assert.equal(result, 'test error');
-      delete process.env.NODE_ENV;
-      done();
+    it('should handle unexpected error', function (done) {
+      var res = this.res;
+      var req = createRequest(correctSigningSecret, this.correctDate, correctRawBody);
+      getRawBodyStub.rejects(new Error('test error'));
+      res.end.callsFake(function (result) {
+        assert.equal(res.statusCode, 500);
+        assert.isUndefined(result);
+        done();
+      });
+      this.requestListener(req, res);
     });
-    this.requestListener(req, res);
-  });
 
-  it('should set an identification header in its responses', function (done) {
-    var emit = this.emit;
-    var res = this.res;
-    var req = createRequest(correctSigningSecret, this.correctDate, correctRawBody);
-    emit.resolves({ status: 200 });
-    getRawBodyStub.resolves(correctRawBody);
-    res.end.callsFake(function () {
-      assert(res.setHeader.calledWith('X-Slack-Powered-By'));
-      done();
+    it('should provide message with unexpected errors in development', function (done) {
+      var res = this.res;
+      var req = createRequest(correctSigningSecret, this.correctDate, correctRawBody);
+      process.env.NODE_ENV = 'development';
+      getRawBodyStub.rejects(new Error('test error'));
+      res.end.callsFake(function (result) {
+        assert.equal(res.statusCode, 500);
+        assert.equal(result, 'test error');
+        delete process.env.NODE_ENV;
+        done();
+      });
+      this.requestListener(req, res);
     });
-    this.requestListener(req, res);
-  });
 
-  it('should respond to url verification requests', function (done) {
-    var res = this.res;
-    var emit = this.emit;
-    var urlVerificationBody = '{"type":"url_verification","challenge": "TEST_CHALLENGE"}';
-    var req = createRequest(correctSigningSecret, this.correctDate, urlVerificationBody);
-    getRawBodyStub.resolves(urlVerificationBody);
-    res.end.callsFake(function () {
-      assert(emit.notCalled);
-      assert.equal(res.statusCode, 200);
-      done();
+    it('should set an identification header in its responses', function (done) {
+      var emit = this.emit;
+      var res = this.res;
+      var req = createRequest(correctSigningSecret, this.correctDate, correctRawBody);
+      emit.resolves({ status: 200 });
+      getRawBodyStub.resolves(correctRawBody);
+      res.end.callsFake(function () {
+        assert(res.setHeader.calledWith('X-Slack-Powered-By'));
+        done();
+      });
+      this.requestListener(req, res);
     });
-    this.requestListener(req, res);
+
+    it('should respond to url verification requests', function (done) {
+      var res = this.res;
+      var emit = this.emit;
+      var urlVerificationBody = '{"type":"url_verification","challenge": "TEST_CHALLENGE"}';
+      var req = createRequest(correctSigningSecret, this.correctDate, urlVerificationBody);
+      getRawBodyStub.resolves(urlVerificationBody);
+      res.end.callsFake(function () {
+        assert(emit.notCalled);
+        assert.equal(res.statusCode, 200);
+        done();
+      });
+      this.requestListener(req, res);
+    });
   });
 });

--- a/test/unit/test-index.js
+++ b/test/unit/test-index.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var assert = require('chai').assert;
+var library = require('../../dist');
+
+describe('@slack/events-api', function () {
+  it('should export "verifyRequestSignature"', function () {
+    assert.property(library, 'verifyRequestSignature');
+  });
+
+  it('should export "createEventAdapter"', function () {
+    assert.property(library, 'createEventAdapter');
+  });
+
+  it('should export "errorCodes"', function () {
+    assert.property(library, 'errorCodes');
+  });
+});


### PR DESCRIPTION
###  Summary

This PR exports the `verifyRequestSignature` method from the library. Previously this method was only available internally. 

I have also updated the method signature to accept an object with the 2 new parameters `requestSignature` and `requestTimestamp`, so that the client may decide how to retrieve the headers from their request object, rather than accepting a `headers` object with keys for the slack-* headers. Please let me know if you would like to preserve the original method signature and I can revert that change.

Let me know if you have any further questions or feedback!

https://github.com/slackapi/node-slack-events-api/issues/70

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-events-api/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
