### PR TITLE
Use Timing Safe Compare

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "debug": "^2.6.1",
     "lodash.isstring": "^4.0.1",
     "raw-body": "^2.3.3",
+    "tsscmp": "^1.0.6",
     "yargs": "^6.6.0"
   }
 }

--- a/src/http-handler.js
+++ b/src/http-handler.js
@@ -1,6 +1,7 @@
 import debugFactory from 'debug';
 import getRawBody from 'raw-body';
 import crypto from 'crypto';
+import timingSafeCompare from 'tsscmp';
 import { packageIdentifier } from './util';
 
 export const errorCodes = {
@@ -44,7 +45,7 @@ export function verifyRequestSignature({
   const [version, hash] = requestSignature.split('=');
   hmac.update(`${version}:${requestTimestamp}:${body}`);
 
-  if (hash !== hmac.digest('hex')) {
+  if (!timingSafeCompare(hash, hmac.digest('hex'))) {
     debug('request signature is not valid');
     const error = new Error('Slack request signing verification failed');
     error.code = errorCodes.SIGNATURE_VERIFICATION_FAILURE;


### PR DESCRIPTION
###  Summary

This PR changes how equality checking is done when verifying the Slack request signature. Currently, `!==` is used; however, this might be vulnerable to [timing attacks](https://codahale.com/a-lesson-in-timing-attacks/), and a timing safe compare function should be used instead.

I introduce the [`tsscmp`](https://github.com/suryagh/tsscmp) package (a wrapper around Node's [`crypto.timingSafeEqual`](https://nodejs.org/api/crypto.html#crypto_crypto_timingsafeequal_a_b)) and use its compare function instead.

Note, the API docs do recommend using a timing safe compare function (See: ["Step-by-step walk-through for validating a request"](https://api.slack.com/docs/verifying-requests-from-slack)), and the [Python library](https://github.com/slackapi/python-slack-events-api/blob/6a269ed11fc46d7b14edd1fc11caf655922bf1a6/slackeventsapi/server.py#L47) verifies this way.

Related: slackapi/node-slack-interactive-messages#71

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-events-api/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
