### PR TITLE
Change parameter for postMessage in reaction_added

### DIFF
--- a/examples/greet-and-react/index.js
+++ b/examples/greet-and-react/index.js
@@ -92,7 +92,7 @@ slackEvents.on('reaction_added', (event, body) => {
     return console.error('No authorization found for this team. Did you install this app again after restarting?');
   }
   // Respond to the reaction back with the same emoji
-  slack.chat.postMessage(event.item.channel, `:${event.reaction}:`)
+  slack.chat.postMessage({ channel: event.item.channel, text: `:${event.reaction}:` })
     .catch(console.error);
 });
 


### PR DESCRIPTION
###  Summary

After running the example demo, I received error regarding the responding to reactions (reaction_added event). The issue #54 describes the same issue and fixes it for the 'message' event, but not for the 'reaction_added' event. The pullrequest also implements that same fix for the ' reaction_added' event.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-events-api/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
