### PR TITLE
Adding support for pre-parsed requests

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -6,10 +6,6 @@ import { createHTTPHandler } from './http-handler';
 
 const debug = debugFactory('@slack/events-api:adapter');
 
-export const errorCodes = {
-  BODY_PARSER_NOT_PERMITTED: 'SLACKADAPTER_BODY_PARSER_NOT_PERMITTED_FAILURE',
-};
-
 export class SlackEventAdapter extends EventEmitter {
   constructor(signingSecret, options = {}) {
     if (!isString(signingSecret)) {
@@ -69,14 +65,7 @@ export class SlackEventAdapter extends EventEmitter {
 
   expressMiddleware(middlewareOptions = {}) {
     const requestListener = this.requestListener(middlewareOptions);
-    return (req, res, next) => {
-      // If parser is being used, we can't verify request signature
-      if (req.body) {
-        const error = new Error('Parsing request body prohibits request signature verification');
-        error.code = errorCodes.BODY_PARSER_NOT_PERMITTED;
-        next(error);
-        return;
-      }
+    return (req, res, next) => { // eslint-disable-line no-unused-vars
       requestListener(req, res);
     };
   }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -31,7 +31,26 @@ function createRequest(signingSecret, ts, rawBody) {
     'content-type': 'application/json'
   };
   return {
-    body: rawBody,
+    headers: headers
+  };
+}
+
+/**
+ * Creates request object with proper headers and a rawBody field payload
+ * @param {string} signingSecret - A Slack signing secret for request verification
+ * @param {Integer} ts - A timestamp for request verification and header
+ * @param {string} rawBody - String of raw body to be put in rawBody field
+ * @returns {Object} pseudo request object
+ */
+function createRawBodyRequest(signingSecret, ts, rawBody) {
+  const signature = createRequestSignature(signingSecret, ts, rawBody);
+  const headers = {
+    'x-slack-signature': signature,
+    'x-slack-request-timestamp': ts,
+    'content-type': 'application/json'
+  };
+  return {
+    rawBody: Buffer.from(rawBody),
     headers: headers
   };
 }
@@ -79,6 +98,7 @@ function completionAggregator(done, totalParts) {
 }
 
 module.exports.createRequest = createRequest;
+module.exports.createRawBodyRequest = createRawBodyRequest;
 module.exports.createRequestSignature = createRequestSignature;
 module.exports.createStreamRequest = createStreamRequest;
 exports.completionAggregator = completionAggregator;

--- a/test/unit/test-adapter.js
+++ b/test/unit/test-adapter.js
@@ -6,7 +6,6 @@ var getRandomPort = require('get-random-port');
 var EventEmitter = require('events');
 var systemUnderTest = require('../../dist/adapter');
 var createStreamRequest = require('../helpers').createStreamRequest;
-var errorCodes = systemUnderTest.errorCodes;
 var SlackEventAdapter = systemUnderTest.default;
 
 // fixtures and test helpers
@@ -80,17 +79,6 @@ describe('SlackEventAdapter', function () {
     it('should return a function', function () {
       var middleware = this.adapter.expressMiddleware();
       assert.isFunction(middleware);
-    });
-    it('should error when body parser is used', function (done) {
-      var middleware = this.adapter.expressMiddleware();
-      var req = { body: { } };
-      var res = this.res;
-      var next = this.next;
-      next.callsFake(function (err) {
-        assert.equal(err.code, errorCodes.BODY_PARSER_NOT_PERMITTED);
-        done();
-      });
-      middleware(req, res, next);
     });
     it('should emit on the adapter', function (done) {
       var middleware = this.adapter.expressMiddleware();

--- a/test/unit/test-http-handler.js
+++ b/test/unit/test-http-handler.js
@@ -2,6 +2,7 @@ var assert = require('chai').assert;
 var sinon = require('sinon');
 var proxyquire = require('proxyquire');
 var createRequest = require('../helpers').createRequest;
+var createRawBodyRequest = require('../helpers').createRawBodyRequest;
 var getRawBodyStub = sinon.stub();
 var systemUnderTest = proxyquire('../../dist/http-handler', {
   'raw-body': getRawBodyStub
@@ -26,7 +27,19 @@ describe('http-handler', function () {
         signingSecret: correctSigningSecret,
         requestTimestamp: req.headers['x-slack-request-timestamp'],
         requestSignature: req.headers['x-slack-signature'],
-        body: req.body
+        body: correctRawBody
+      });
+
+      assert.isTrue(isVerified);
+    });
+
+    it('should return true for a valid request with a rawBody payload', function () {
+      var req = createRawBodyRequest(correctSigningSecret, this.correctDate, correctRawBody);
+      var isVerified = verifyRequestSignature({
+        signingSecret: correctSigningSecret,
+        requestTimestamp: req.headers['x-slack-request-timestamp'],
+        requestSignature: req.headers['x-slack-signature'],
+        body: req.rawBody.toString()
       });
 
       assert.isTrue(isVerified);
@@ -64,7 +77,19 @@ describe('http-handler', function () {
       var res = this.res;
       var req = createRequest(correctSigningSecret, this.correctDate, correctRawBody);
       emit.resolves({ status: 200 });
-      getRawBodyStub.resolves(correctRawBody);
+      getRawBodyStub.resolves(Buffer.from(correctRawBody));
+      res.end.callsFake(function () {
+        assert.equal(res.statusCode, 200);
+        done();
+      });
+      this.requestListener(req, res);
+    });
+
+    it('should verify a correct signing secret for a payload with a rawBody field', function (done) {
+      var emit = this.emit;
+      var res = this.res;
+      var req = createRawBodyRequest(correctSigningSecret, this.correctDate, correctRawBody);
+      emit.resolves({ status: 200 });
       res.end.callsFake(function () {
         assert.equal(res.statusCode, 200);
         done();
@@ -75,7 +100,7 @@ describe('http-handler', function () {
     it('should fail request signing verification with an incorrect signing secret', function (done) {
       var res = this.res;
       var req = createRequest('INVALID_SECRET', this.correctDate, correctRawBody);
-      getRawBodyStub.resolves(correctRawBody);
+      getRawBodyStub.resolves(Buffer.from(correctRawBody));
       res.end.callsFake(function () {
         assert.equal(res.statusCode, 404);
         done();
@@ -87,7 +112,7 @@ describe('http-handler', function () {
       var res = this.res;
       var sixMinutesAgo = Math.floor(Date.now() / 1000) - (60 * 6);
       var req = createRequest(correctSigningSecret, sixMinutesAgo, correctRawBody);
-      getRawBodyStub.resolves(correctRawBody);
+      getRawBodyStub.resolves(Buffer.from(correctRawBody));
       res.end.callsFake(function () {
         assert.equal(res.statusCode, 404);
         done();
@@ -126,7 +151,7 @@ describe('http-handler', function () {
       var res = this.res;
       var req = createRequest(correctSigningSecret, this.correctDate, correctRawBody);
       emit.resolves({ status: 200 });
-      getRawBodyStub.resolves(correctRawBody);
+      getRawBodyStub.resolves(Buffer.from(correctRawBody));
       res.end.callsFake(function () {
         assert(res.setHeader.calledWith('X-Slack-Powered-By'));
         done();
@@ -139,7 +164,7 @@ describe('http-handler', function () {
       var emit = this.emit;
       var urlVerificationBody = '{"type":"url_verification","challenge": "TEST_CHALLENGE"}';
       var req = createRequest(correctSigningSecret, this.correctDate, urlVerificationBody);
-      getRawBodyStub.resolves(urlVerificationBody);
+      getRawBodyStub.resolves(Buffer.from(urlVerificationBody));
       res.end.callsFake(function () {
         assert(emit.notCalled);
         assert.equal(res.statusCode, 200);


### PR DESCRIPTION
###  Summary

Some server-less cloud providers (e.g. Google Firebase Cloud Functions) are populating the request with a body parser before it can be parsed by the SDK. To prevent the middleware of throwing an error, it checks the request if it exposes a raw body in the `request.rawBody` variable.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-events-api/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
