### PR TITLE
remove node 4.2 from test matrix (superceded by v4)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ node_js:
   - "6"
   - "5"
   - "4"
-  - "4.2"
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
Should fix test failure in #90 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/node-slack-events-api/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
